### PR TITLE
Adding configuration for Bitwarden Passwordless.dev

### DIFF
--- a/src/cambiato/__init__.py
+++ b/src/cambiato/__init__.py
@@ -8,13 +8,16 @@ devices such as district heating and electricity meters.
 from cambiato import database as db
 from cambiato.app import APP_PATH
 from cambiato.config import (
+    BITWARDEN_PASSWORDLESS_API_URL,
     CONFIG_DIR,
     CONFIG_FILE_ENV_VAR,
     CONFIG_FILE_PATH,
     CONFIG_FILENAME,
     PROG_NAME,
+    BitwardenPasswordlessConfig,
     ConfigManager,
     DatabaseConfig,
+    Language,
     load_config,
 )
 from cambiato.exceptions import (
@@ -38,13 +41,16 @@ __all__ = [
     '__version__',
     '__versiontuple__',
     # config
+    'BITWARDEN_PASSWORDLESS_API_URL',
     'CONFIG_DIR',
     'CONFIG_FILE_ENV_VAR',
     'CONFIG_FILE_PATH',
     'CONFIG_FILENAME',
     'PROG_NAME',
+    'BitwardenPasswordlessConfig',
     'ConfigManager',
     'DatabaseConfig',
+    'Language',
     'load_config',
     # database
     'db',

--- a/src/cambiato/config.py
+++ b/src/cambiato/config.py
@@ -5,12 +5,13 @@ import logging
 import os
 import sys
 import tomllib
+from enum import StrEnum
 from pathlib import Path
 from typing import Any
 
 # Third party
 import streamlit_passwordless as stp
-from pydantic import ConfigDict, Field, field_validator
+from pydantic import AliasChoices, AnyHttpUrl, ConfigDict, Field, field_validator
 from sqlalchemy import URL
 
 # Local
@@ -34,6 +35,16 @@ CONFIG_FILE_PATH = CONFIG_DIR / CONFIG_FILENAME
 
 # The name of the environment variable, which points to the config file.
 CONFIG_FILE_ENV_VAR = 'CAMBIATO_CONFIG_FILE'
+
+# The default url to the Bitwarden Passwordless.dev backend API.
+BITWARDEN_PASSWORDLESS_API_URL = stp.BITWARDEN_PASSWORDLESS_API_URL
+
+
+class Language(StrEnum):
+    r"""The available languages of Cambiato."""
+
+    EN = 'English'
+    SV = 'Swedish'
 
 
 class BaseConfigModel(BaseModel):
@@ -89,7 +100,30 @@ class DatabaseConfig(BaseConfigModel):
         try:
             return stp.db.create_db_url(url)
         except stp.DatabaseInvalidUrlError as e:
-            raise ValueError(f'{type(e).__name__} : {str(e)}') from None
+            raise ValueError(f'{type(e).__name__} : {e!s}') from None
+
+
+class BitwardenPasswordlessConfig(BaseConfigModel):
+    r"""The configuration for Bitwarden Passwordless.dev.
+
+    Bitwarden Passwordless.dev handles the passkey registration and authentication.
+
+    Parameters
+    ----------
+    public_key : str, default ''
+         The public key of the Bitwarden Passwordless.dev backend API.
+
+    private_key : str, default ''
+         The private key of the Bitwarden Passwordless.dev backend API.
+
+    url : pydantic.AnyHttpUrl or str, default default 'https://v4.passwordless.dev'
+        The base url of the backend API of Bitwarden Passwordless.dev. Specify this url
+        if you are self-hosting Bitwarden Passwordless.dev.
+    """
+
+    public_key: str
+    private_key: str
+    url: AnyHttpUrl = stp.BITWARDEN_PASSWORDLESS_API_URL
 
 
 class ConfigManager(BaseConfigModel):
@@ -102,14 +136,24 @@ class ConfigManager(BaseConfigModel):
         The special path '-' specifies that the config was loaded from stdin.
         If None the default configuration was loaded.
 
+    language : cambiato.Language, default cambiato.Language.EN
+        The default language to use when starting the application. The default is English.
+
     database : cambiato.DatabaseConfig
         The database configuration.
+
+    bwp : cambiato.BitwardenPasswordlessConfig
+        The configuration for Bitwarden Passwordless.dev.
     """
 
     model_config = ConfigDict(frozen=True)
 
     config_file_path: Path | None = None
+    language: Language = Language.EN
     database: DatabaseConfig = Field(default_factory=DatabaseConfig)
+    bwp: BitwardenPasswordlessConfig = Field(
+        validation_alias=AliasChoices('bwp', 'bitwarden_passwordless', 'bitwarden_passwordless_dev')
+    )
 
 
 def load_config(path: Path | None = None) -> ConfigManager:
@@ -145,7 +189,7 @@ def load_config(path: Path | None = None) -> ConfigManager:
     Raises
     ------
     cambiato.ConfigError
-        If the configuration is invalid.
+        If the configuration is invalid or if no configuration was found.
 
     cambiato.ConfigFileNotFoundError
         If the configuration file could not be found.
@@ -154,15 +198,15 @@ def load_config(path: Path | None = None) -> ConfigManager:
         If there are syntax errors in the config file.
     """
 
+    file_path: Path | None = None
+
     if path is None:
         if (_file_path := os.getenv(CONFIG_FILE_ENV_VAR)) is None:
             file_path = CONFIG_FILE_PATH
         else:
             file_path = Path(_file_path)
     else:
-        if path.name == '-':  # stdin
-            file_path = None
-        else:
+        if path.name != '-':  # stdin
             file_path = path
 
     config_content = None
@@ -170,15 +214,13 @@ def load_config(path: Path | None = None) -> ConfigManager:
 
     if file_path:
         file_path_str = str(file_path)
+
         if file_path.is_dir():
             error_msg = f'The config file "{file_path}" must be a file not a directory!'
             raise exceptions.ConfigFileNotFoundError(message=error_msg, data=file_path)
 
         if file_path == CONFIG_FILE_PATH:
-            if file_path.exists():
-                config_content = file_path.read_text()
-            else:
-                config_content = None
+            config_content = file_path.read_text() if file_path.exists() else None
         elif not file_path.exists():
             error_msg = f'The config file "{file_path}" does not exist!'
             raise exceptions.ConfigFileNotFoundError(message=error_msg, data=file_path)
@@ -190,7 +232,7 @@ def load_config(path: Path | None = None) -> ConfigManager:
         file_path_str = '-' if config_content else file_path_str
 
     if not config_content:
-        return ConfigManager(config_file_path=None)
+        raise exceptions.ConfigError('No configuration found! Check your sources!')
 
     config_content = f"config_file_path = '{file_path_str}'\n{config_content}"
 

--- a/tests/config.py
+++ b/tests/config.py
@@ -1,7 +1,13 @@
 r"""Configuration for the test suite of Cambiato."""
 
 # Standard library
+import os
+import tomllib
 from pathlib import Path
+from typing import Any
+
+# Third party
+import pytest
 
 # =============================================================================================
 # Constants
@@ -10,3 +16,99 @@ from pathlib import Path
 TEST_DIR = Path(__file__).parent
 STATIC_FILES_BASE_DIR = TEST_DIR / 'static_files'
 STATIC_FILES_CONFIG_BASE_DIR = STATIC_FILES_BASE_DIR / 'config'
+TEST_SECRETS_FILE_ENV_VAR = 'CAMBIATO_SECRETS_FILE_TEST'
+
+
+# =============================================================================================
+# Secrets
+# =============================================================================================
+
+
+def load_secrets() -> tuple[dict[str, Any], str]:
+    r"""Load the test secrets from the secrets' toml file.
+
+    The path to the toml file should be specified in the
+    environment variable "CAMBIATO_SECRETS_FILE_TEST".
+
+    Returns
+    -------
+    secrets : dict[str, Any]
+        The secrets loaded from the toml file. An empty dict is
+        returned if no secrets could be loaded from the file.
+
+    message : str
+        A message if there was an error loading the test secrets.
+        If no errors an empty string is returned.
+    """
+
+    secrets_file: Path | str | None = os.getenv(TEST_SECRETS_FILE_ENV_VAR)
+    secrets: dict[str, Any] = {}
+
+    if secrets_file is None:
+        return secrets, f'Environment variable "{TEST_SECRETS_FILE_ENV_VAR}" is not set!'
+
+    secrets_file = Path(secrets_file).expanduser()
+
+    if secrets_file.is_dir():
+        return secrets, f'"{secrets_file}" is a directory and not a file!'
+    elif not secrets_file.exists():
+        return secrets, f'"{secrets_file}" does not exist!'
+
+    try:
+        secrets = tomllib.loads(secrets_file.read_text())
+    except (tomllib.TOMLDecodeError, TypeError) as e:
+        return secrets, f'Syntax error in config : {e.args[0]}'
+
+    return secrets, ''
+
+
+secrets, message = load_secrets()
+
+DB_URL_SECRETS_KEY = 'DB_URL'
+DB_URL = secrets.get(DB_URL_SECRETS_KEY)
+
+BWP_PUBLIC_KEY_SECRETS_KEY = 'bwp_public_key'
+BWP_PUBLIC_KEY = secrets.get(BWP_PUBLIC_KEY_SECRETS_KEY)
+
+BWP_PRIVATE_KEY_SECRETS_KEY = 'bwp_private_key'
+BWP_PRIVATE_KEY = secrets.get(BWP_PRIVATE_KEY_SECRETS_KEY)
+
+BWP_URL_SECRETS_KEY = 'bwp_url'
+BWP_URL = secrets.get(BWP_URL_SECRETS_KEY)
+
+
+# =============================================================================================
+# Skip markers
+# =============================================================================================
+
+# Database
+# ---------------------------------------------------------------------------------------------
+can_run_db_integration_tests = DB_URL is not None
+
+if message:
+    db_integration_tests_skip_reason = (
+        f'{message}\nSecrets missing: {DB_URL_SECRETS_KEY} = {DB_URL}'
+    )
+else:
+    db_integration_tests_skip_reason = ''
+
+db_integration_test_skipif = pytest.mark.skipif(
+    not can_run_db_integration_tests, reason=db_integration_tests_skip_reason
+)
+
+# Bitwarden Passwordless.dev
+# ---------------------------------------------------------------------------------------------
+can_run_bwp_integration_tests = BWP_PUBLIC_KEY is not None and BWP_PRIVATE_KEY is not None
+
+if message:
+    bwp_integration_tests_skip_reason = (
+        f'{message}\nSecrets missing:\n'
+        f'{BWP_PUBLIC_KEY_SECRETS_KEY} = {BWP_PUBLIC_KEY}, '
+        f'{BWP_PRIVATE_KEY_SECRETS_KEY} = {BWP_PRIVATE_KEY}'
+    )
+else:
+    bwp_integration_tests_skip_reason = ''
+
+bwp_integration_test_skipif = pytest.mark.skipif(
+    not can_run_bwp_integration_tests, reason=bwp_integration_tests_skip_reason
+)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,25 +8,116 @@ from typing import Any
 
 # Third party
 import pytest
-from sqlalchemy import make_url
+from pydantic import AnyHttpUrl
+from sqlalchemy import URL, make_url
 
 # Local
 import cambiato.config
-from cambiato.config import CONFIG_FILE_ENV_VAR
-from tests.config import STATIC_FILES_CONFIG_BASE_DIR
+from cambiato.config import BITWARDEN_PASSWORDLESS_API_URL, CONFIG_FILE_ENV_VAR, Language
+from tests.config import (
+    BWP_PRIVATE_KEY,
+    BWP_PUBLIC_KEY,
+    BWP_URL,
+    DB_URL,
+    STATIC_FILES_CONFIG_BASE_DIR,
+)
 
 type ConfigDict = dict[str, Any]
 
 
-@pytest.fixture()
+@pytest.fixture(scope='session')
+def db_url() -> tuple[str, URL]:
+    r"""The url to the test database.
+
+    If the URL cannot be loaded from the test configuration of `DB_URL`
+    a syntactically valid dummy URL to the database is provided.
+
+    Returns
+    -------
+    url_str : str
+        A string version of the database url.
+
+    url : sqlalchemy.URL
+        A SQLAlchemy URL of `url_str`.
+    """
+
+    url_str = 'postgresql+psycopg2://user:pw@myserver:5432/postgresdb' if DB_URL is None else DB_URL
+
+    return url_str, make_url(url_str)
+
+
+@pytest.fixture(scope='session')
+def bwp_public_key() -> str:
+    r"""The public key to the test instance of Bitwarden Passwordless.dev.
+
+    If the public key cannot be loaded from the test configuration
+    of `BWP_PUBLIC_KEY` a dummy key is provided.
+
+    Returns
+    -------
+    str
+        The public key to the test instance of Bitwarden Passwordless.dev.
+    """
+
+    return 'bwp_public_key' if BWP_PUBLIC_KEY is None else BWP_PUBLIC_KEY
+
+
+@pytest.fixture(scope='session')
+def bwp_private_key() -> str:
+    r"""The private key to the test instance of Bitwarden Passwordless.dev.
+
+    If the private key cannot be loaded from the test configuration
+    of `BWP_PRIVATE_KEY` a dummy key is provided.
+
+    Returns
+    -------
+    str
+        The private key to the test instance of Bitwarden Passwordless.dev.
+    """
+
+    return 'bwp_private_key' if BWP_PRIVATE_KEY is None else BWP_PRIVATE_KEY
+
+
+@pytest.fixture(scope='session')
+def bwp_url() -> tuple[str, AnyHttpUrl]:
+    r"""The base url to the Bitwarden Passwordless.dev backend API.
+
+    If the url cannot be loaded from the test configuration
+    of `BWP_URL` the default url of Bitwarden Passwordless.dev is used.
+
+    Returns
+    -------
+    url_str : str
+        A string version of the API url.
+
+    url : pydantic.AnyHttpUrl
+        The pydantic URL of `url_str`.
+    """
+
+    if BWP_URL is None:
+        url_str = str(BITWARDEN_PASSWORDLESS_API_URL)
+        url = BITWARDEN_PASSWORDLESS_API_URL
+    else:
+        url_str = BWP_URL
+        url = AnyHttpUrl(BWP_URL)
+
+    return url_str, url
+
+
+@pytest.fixture
 def remove_config_file_env_var(monkeypatch: pytest.MonkeyPatch) -> None:
     r"""Remove the config file environment variable CAMBIATO_CONFIG_FILE."""
 
     monkeypatch.delenv(CONFIG_FILE_ENV_VAR, raising=False)
 
 
-@pytest.fixture()
-def config_data(tmp_path: Path) -> tuple[str, dict[str, Any], Path]:
+@pytest.fixture
+def config_data(
+    db_url: tuple[str, URL],
+    bwp_public_key: str,
+    bwp_private_key: str,
+    bwp_url: tuple[str, AnyHttpUrl],
+) -> tuple[str, dict[str, Any]]:
     r"""A Cambiato configuration with a SQLite database.
 
     Returns
@@ -36,9 +127,6 @@ def config_data(tmp_path: Path) -> tuple[str, dict[str, Any], Path]:
 
     config_exp : dict[str, Any]
         The expected configuration after loading and parsing `config_data_str`.
-
-    db_path : Path
-        The full path to the SQLite database. The database does not exist.
     """
 
     source_filename = 'Cambiato.toml'
@@ -48,13 +136,18 @@ def config_data(tmp_path: Path) -> tuple[str, dict[str, Any], Path]:
 
     config_data_str = source_config_file_path.read_text()
 
-    db_path = tmp_path / 'Cambiato.db'
-    url = f'sqlite:///{str(db_path)}'
+    db_url_str, db_url_sqlalchemy = db_url
+    bwp_url_str, bwp_url_pydantic = bwp_url
 
-    config_data_str = config_data_str.replace(':url', url)
+    config_data_str = (
+        config_data_str.replace(':db_url', db_url_str)
+        .replace(':bwp_public_key', bwp_public_key)
+        .replace(':bwp_private_key', bwp_private_key)
+        .replace(':bwp_url', bwp_url_str)
+    )
 
     database_config: ConfigDict = {
-        'url': tuple(make_url(url)),
+        'url': tuple(db_url_sqlalchemy),
         'autoflush': False,
         'expire_on_commit': True,
         'create_database': True,
@@ -62,14 +155,24 @@ def config_data(tmp_path: Path) -> tuple[str, dict[str, Any], Path]:
         'engine_config': {'echo': True},
     }
 
-    config_exp: ConfigDict = {'database': database_config}
+    bwp_config: ConfigDict = {
+        'public_key': bwp_public_key,
+        'private_key': bwp_private_key,
+        'url': bwp_url_pydantic,
+    }
 
-    return config_data_str, config_exp, db_path
+    config_exp: ConfigDict = {
+        'language': Language.EN,
+        'database': database_config,
+        'bwp': bwp_config,
+    }
+
+    return config_data_str, config_exp
 
 
-@pytest.fixture()
+@pytest.fixture
 def config_file(
-    config_data: tuple[str, dict[str, Any], Path], tmp_path: Path
+    config_data: tuple[str, dict[str, Any]], tmp_path: Path
 ) -> tuple[Path, str, dict[str, Any]]:
     r"""A Cambiato config file.
 
@@ -85,7 +188,7 @@ def config_file(
         The expected configuration after loading `config_file_path`.
     """
 
-    config_data_str, config_exp_original, _ = config_data
+    config_data_str, config_exp_original = config_data
 
     config_file_path = tmp_path / 'Cambiato.toml'
     config_file_path.write_text(config_data_str)
@@ -96,10 +199,10 @@ def config_file(
     return config_file_path, config_data_str, config_exp
 
 
-@pytest.fixture()
+@pytest.fixture
 def config_in_stdin(
-    config_data: tuple[str, dict[str, Any], Path], monkeypatch: pytest.MonkeyPatch
-) -> tuple[str, dict[str, Any], Path]:
+    config_data: tuple[str, dict[str, Any]], monkeypatch: pytest.MonkeyPatch
+) -> tuple[str, dict[str, Any]]:
     r"""A Cambiato configuration loaded into stdin.
 
     Returns
@@ -109,18 +212,15 @@ def config_in_stdin(
 
     config_exp : dict[str, Any]
         The expected configuration after loading and parsing `config_data_str`.
-
-    db_path : Path
-        The full path to the SQLite database.
     """
 
-    config_data_str, config_exp_original, db_path = config_data
+    config_data_str, config_exp_original = config_data
     config_exp = deepcopy(config_exp_original)
     config_exp['config_file_path'] = Path('-')
 
     monkeypatch.setattr(cambiato.config.sys, 'stdin', io.StringIO(config_data_str))
 
-    return config_data_str, config_exp, db_path
+    return config_data_str, config_exp
 
 
 @pytest.fixture
@@ -130,9 +230,9 @@ def empty_stdin(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(cambiato.config.sys, 'stdin', io.StringIO(''))
 
 
-@pytest.fixture()
+@pytest.fixture
 def config_file_from_config_env_var(
-    config_data: tuple[str, dict[str, Any], Path],
+    config_data: tuple[str, dict[str, Any]],
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> tuple[Path, str, dict[str, Any]]:
@@ -153,7 +253,7 @@ def config_file_from_config_env_var(
         The expected configuration after loading `config_file_path`.
     """
 
-    config_data_str, config_exp_original, _ = config_data
+    config_data_str, config_exp_original = config_data
 
     config_file_path = tmp_path / 'Cambiato_from_env_var.toml'
     config_file_path.write_text(config_data_str)
@@ -166,9 +266,9 @@ def config_file_from_config_env_var(
     return config_file_path, config_data_str, config_exp
 
 
-@pytest.fixture()
+@pytest.fixture
 def config_file_from_default_location(
-    config_data: tuple[str, dict[str, Any], Path],
+    config_data: tuple[str, dict[str, Any]],
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> tuple[Path, str, dict[str, Any]]:
@@ -189,7 +289,7 @@ def config_file_from_default_location(
         The expected configuration after loading `config_file_path`.
     """
 
-    config_data_str, config_exp_original, _ = config_data
+    config_data_str, config_exp_original = config_data
 
     config_file_path = tmp_path / 'Cambiato_from_default_location.toml'
     config_file_path.write_text(config_data_str)
@@ -202,7 +302,26 @@ def config_file_from_default_location(
     return config_file_path, config_data_str, config_exp
 
 
-@pytest.fixture()
+@pytest.fixture
+def default_config_file_location_does_not_exist(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> Path:
+    r"""A mocked default config file location of Cambiato that does not exist.
+
+    Returns
+    -------
+    config_file_path : pathlib.Path
+        The path to the non-existing config file.
+    """
+
+    config_file_path = tmp_path / 'Cambiato_default_does_not_exist.toml'
+
+    monkeypatch.setattr(cambiato.config, 'CONFIG_FILE_PATH', config_file_path)
+
+    return config_file_path
+
+
+@pytest.fixture
 def config_file_with_syntax_error(tmp_path: Path) -> Path:
     r"""A Cambiato config file with syntax errors.
 

--- a/tests/static_files/config/Cambiato.toml
+++ b/tests/static_files/config/Cambiato.toml
@@ -1,5 +1,5 @@
 [database]
-url = ':url'
+url = ':db_url'
 autoflush = false
 expire_on_commit = true
 create_database = true
@@ -9,3 +9,8 @@ timeout = 30
 
 [database.engine_config]
 echo = true
+
+[bitwarden_passwordless]
+public_key = ':bwp_public_key'
+private_key = ':bwp_private_key'
+url = ':bwp_url'


### PR DESCRIPTION
Bitwarden Passwordless.dev handles the passkey registration and authentication and will be used (through streamlit_passwordless) to authenticate users in Cambiato.