### PR TITLE
Adding sign in and register page

### DIFF
--- a/src/cambiato/app/_pages/__init__.py
+++ b/src/cambiato/app/_pages/__init__.py
@@ -8,3 +8,4 @@ class Pages(StrEnum):
     r"""The pages of the application."""
 
     HOME = '_pages/home.py'
+    SIGN_IN = '_pages/sign_in.py'

--- a/src/cambiato/app/_pages/home.py
+++ b/src/cambiato/app/_pages/home.py
@@ -4,6 +4,8 @@ r"""The entry point of the home page."""
 import streamlit as st
 
 # Local
+from cambiato.app import auth
+from cambiato.app._pages import Pages
 from cambiato.app.config import (
     APP_HOME_PAGE_URL,
     APP_ISSUES_PAGE_URL,
@@ -17,11 +19,12 @@ The simple yet powerful system for changing utility devices.
 """
 
 
+@auth.authorized(redirect=Pages.SIGN_IN)
 def home_page() -> None:
     r"""Run the home page of the Cambiato web app."""
 
     st.set_page_config(
-        page_title='Home - Cambiato',
+        page_title='Cambiato - Home',
         page_icon=':cyclone:',
         layout='wide',
         menu_items={
@@ -29,6 +32,7 @@ def home_page() -> None:
             'Get Help': APP_HOME_PAGE_URL,
             'Report a bug': APP_ISSUES_PAGE_URL,
         },
+        initial_sidebar_state='auto',
     )
 
     st.title('Cambiato')

--- a/src/cambiato/app/_pages/sign_in.py
+++ b/src/cambiato/app/_pages/sign_in.py
@@ -1,0 +1,48 @@
+r"""The entry point of the sign in page."""
+
+# Standard library
+from pathlib import Path
+
+# Third party
+import streamlit as st
+
+# Local
+from cambiato.app import auth
+from cambiato.app.config import (
+    APP_HOME_PAGE_URL,
+    APP_ISSUES_PAGE_URL,
+    MAINTAINER_INFO,
+)
+from cambiato.app.controller.sign_in import controller
+from cambiato.app.setup import bwp_client, session_factory
+
+SIGN_IN_PATH = Path(__file__)
+
+ABOUT = f"""Sign in to Cambiato or register an account.
+
+{MAINTAINER_INFO}
+"""
+
+
+def sign_in_page() -> None:
+    r"""Run the sign in page of Cambiato."""
+
+    authenticated = auth.authenticated()
+    st.set_page_config(
+        page_title='Cambiato - Sign in',
+        page_icon=':sparkles:',
+        layout='centered',
+        menu_items={
+            'Get Help': APP_HOME_PAGE_URL,
+            'Report a bug': APP_ISSUES_PAGE_URL,
+            'About': ABOUT,
+        },
+        initial_sidebar_state='auto' if authenticated else 'collapsed',
+    )
+
+    with session_factory() as session:
+        controller(session=session, client=bwp_client, authenticated=authenticated)
+
+
+if __name__ == '__main__' or __name__ == '__page__':
+    sign_in_page()

--- a/src/cambiato/app/auth.py
+++ b/src/cambiato/app/auth.py
@@ -1,0 +1,28 @@
+r"""User authentication and authorization."""
+
+# Third party
+import streamlit as st
+import streamlit_passwordless as stp
+from streamlit_passwordless import authorized as authorized
+
+# Local
+from cambiato.app.session_state import AUTHENTICATED
+
+
+def authenticated(user: stp.User | None = None) -> bool:
+    r"""Check if the current user is authenticated.
+
+    Parameters
+    ----------
+    user : streamlit_passwordless.User or None, default None
+        The user for which to check the authentication status.
+        The default option is to fetch the current user from the
+        session state.
+    """
+
+    if st.session_state.get(AUTHENTICATED, False) is True:
+        return True
+
+    user = stp.get_current_user() if user is None else user
+
+    return user is not None and user.is_authenticated

--- a/src/cambiato/app/components/__init__.py
+++ b/src/cambiato/app/components/__init__.py
@@ -1,0 +1,1 @@
+r"""The components that make up the web app."""

--- a/src/cambiato/app/components/sidebar.py
+++ b/src/cambiato/app/components/sidebar.py
@@ -1,0 +1,25 @@
+r"""Sidebar components."""
+
+# Third party
+import streamlit as st
+import streamlit_passwordless as stp
+
+# Local
+from cambiato.app.session_state import AUTHENTICATED
+
+
+def sidebar(authenticated: bool) -> None:
+    r"""Render the sidebar.
+
+    Parameters
+    ----------
+    authenticated : bool
+        True if the user is authenticated and False otherwise.
+    """
+
+    if not authenticated:
+        return
+
+    with st.sidebar:
+        if stp.sign_out_button():
+            st.session_state[AUTHENTICATED] = False

--- a/src/cambiato/app/config.py
+++ b/src/cambiato/app/config.py
@@ -1,5 +1,8 @@
 r"""The configuration of the Cambiato web app."""
 
+# Third party
+import streamlit_passwordless as stp
+
 # Local
 from cambiato.metadata import __releasedate__, __version__
 
@@ -10,3 +13,8 @@ MAINTAINER_INFO = f"""\
 
 APP_HOME_PAGE_URL = 'https://github.com/antonlydell/Cambiato'
 APP_ISSUES_PAGE_URL = 'https://github.com/antonlydell/Cambiato/issues'
+
+ICON_INFO = stp.ICON_INFO
+ICON_SUCCESS = stp.ICON_SUCCESS
+ICON_WARNING = stp.ICON_WARNING
+ICON_ERROR = stp.ICON_ERROR

--- a/src/cambiato/app/controller/sign_in.py
+++ b/src/cambiato/app/controller/sign_in.py
@@ -1,0 +1,49 @@
+r"""The page controller of the sign in page."""
+
+# Third party
+import streamlit as st
+import streamlit_passwordless as stp
+
+# Local
+from cambiato.app._pages import Pages
+from cambiato.database import Session
+
+
+def controller(
+    session: Session, client: stp.BitwardenPasswordlessClient, authenticated: bool = False
+) -> None:
+    r"""Render the sign in and register page.
+
+    Parameters
+    ----------
+    session : cambiato.db.Session
+        An active session to the Cambiato database.
+
+    client : streamlit_passwordless.BitwardenPasswordlessClient
+        The client for interacting with the backend API of Bitwarden Passwordless.dev.
+
+    authenticated : bool
+        True if the user is authenticated and False otherwise.
+    """
+
+    st.title('Cambiato')
+
+    with st.container(border=True):
+        if authenticated:
+            stp.bitwarden_register_form_existing_user(
+                client=client, db_session=session, border=False
+            )
+        else:
+            stp.bitwarden_register_form(
+                client=client,
+                db_session=session,
+                pre_authorized=True,
+                with_displayname=False,
+                with_email=False,
+                border=False,
+                redirect=Pages.HOME,
+            )
+        st.write('Already have an account?')
+        stp.bitwarden_sign_in_button(
+            client=client, db_session=session, with_autofill=True, redirect=Pages.HOME
+        )

--- a/src/cambiato/app/main.py
+++ b/src/cambiato/app/main.py
@@ -5,9 +5,12 @@ from pathlib import Path
 
 # Third party
 import streamlit as st
+import streamlit_passwordless as stp
 
 # Local
+from cambiato.app import auth
 from cambiato.app._pages import Pages
+from cambiato.app.components.sidebar import sidebar
 
 APP_PATH = Path(__file__)
 
@@ -15,8 +18,17 @@ APP_PATH = Path(__file__)
 def main() -> None:
     r"""The page router of the Cambiato web app."""
 
-    pages = [st.Page(page=Pages.HOME, title='Home', default=True)]
-    page = st.navigation(pages, position='sidebar')
+    stp.init_session_state()
+    authenticated = auth.authenticated()
+
+    pages = [
+        st.Page(page=Pages.HOME, title='Home'),
+        st.Page(page=Pages.SIGN_IN, title='Sign in and register', default=True),
+    ]
+    page = st.navigation(pages, position='top' if authenticated else 'hidden')
+
+    sidebar(authenticated=authenticated)
+
     page.run()
 
 

--- a/src/cambiato/app/session_state.py
+++ b/src/cambiato/app/session_state.py
@@ -1,0 +1,4 @@
+r"""Keys of the session state of the web app."""
+
+# True if the user is authenticated and False otherwise.
+AUTHENTICATED = 'authenticated'

--- a/src/cambiato/app/setup.py
+++ b/src/cambiato/app/setup.py
@@ -1,0 +1,45 @@
+r"""Setup the resources needed by the Cambiato web app."""
+
+# Standard library
+import logging
+
+# Third party
+import streamlit as st
+import streamlit_passwordless as stp
+
+# Local
+from cambiato import exceptions
+from cambiato.app.config import ICON_ERROR
+from cambiato.config import load_config
+from cambiato.database import create_session_factory
+from cambiato.log import setup_logging
+
+logger = logging.getLogger(__name__)
+
+
+try:
+    cm = load_config()
+except exceptions.ConfigError as e:
+    logger.error(e.detailed_message)
+    st.error('Error loading configuration! Check the logs for more details.', icon=ICON_ERROR)
+    st.stop()
+
+setup_logging(config=cm.logging)
+
+try:
+    session_factory = create_session_factory(
+        url=cm.database.url,
+        autoflush=cm.database.autoflush,
+        expire_on_commit=cm.database.expire_on_commit,
+        create_database=True,
+        connect_args=cm.database.connect_args,
+        **cm.database.engine_config,
+    )
+except exceptions.SQLAlchemyError as e:
+    logger.error(f'Error creating session factory:\n{e!s}')
+    st.error('Error connecting to database! Check the logs for more details.', icon=ICON_ERROR)
+    st.stop()
+
+bwp_client = stp.BitwardenPasswordlessClient(
+    public_key=cm.bwp.public_key, private_key=cm.bwp.private_key
+)

--- a/src/cambiato/exceptions.py
+++ b/src/cambiato/exceptions.py
@@ -3,6 +3,9 @@ r"""The exception hierarchy of Cambiato."""
 # Standard library
 from typing import Any
 
+# Third party
+from sqlalchemy.exc import SQLAlchemyError as SQLAlchemyError
+
 
 class CambiatoError(Exception):
     r"""The base Exception of Cambiato.


### PR DESCRIPTION
The app now has a sign in page where a user can also register a passkey, given that the user exists in the database.
Added a sign out button to the sidebar of all pages. Implemented the functionality to be able to sign in and sign out.