### PR TITLE
Adding first draft of the order page

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+recursive-include src/cambiato/app/translations/translations *

--- a/src/cambiato/app/_pages/__init__.py
+++ b/src/cambiato/app/_pages/__init__.py
@@ -9,3 +9,4 @@ class Pages(StrEnum):
 
     HOME = '_pages/home.py'
     SIGN_IN = '_pages/sign_in.py'
+    ORDER = '_pages/order.py'

--- a/src/cambiato/app/_pages/order.py
+++ b/src/cambiato/app/_pages/order.py
@@ -1,0 +1,51 @@
+r"""The entry point of the order page."""
+
+# Standard library
+from pathlib import Path
+
+# Third party
+import streamlit as st
+
+# Local
+from cambiato.app import auth
+from cambiato.app._pages import Pages
+from cambiato.app.config import (
+    APP_HOME_PAGE_URL,
+    APP_ISSUES_PAGE_URL,
+    MAINTAINER_INFO,
+)
+from cambiato.app.controller.order import controller
+from cambiato.app.setup import cm, session_factory, translations
+
+ORDER_PAGE_PATH = Path(__file__)
+
+ABOUT = f"""Create and manage orders.
+
+{MAINTAINER_INFO}
+"""
+
+
+@auth.authorized(redirect=Pages.SIGN_IN)
+def order_page() -> None:
+    r"""Render the order page."""
+
+    st.set_page_config(
+        page_title='Cambiato - Order',
+        page_icon=':bookmark_tabs:',
+        layout='wide',
+        menu_items={
+            'Get Help': APP_HOME_PAGE_URL,
+            'Report a bug': APP_ISSUES_PAGE_URL,
+            'About': ABOUT,
+        },
+        initial_sidebar_state='auto',
+    )
+
+    translation = translations[cm.default_language]
+
+    with session_factory() as session:
+        controller(session=session, translation=translation.order)
+
+
+if __name__ in {'__main__', '__page__'}:
+    order_page()

--- a/src/cambiato/app/components/core.py
+++ b/src/cambiato/app/components/core.py
@@ -1,0 +1,10 @@
+r"""Core functionality of the components."""
+
+# Standard library
+from typing import TypeAlias
+
+# Third party
+from streamlit_passwordless import BannerContainer as BannerContainer
+from streamlit_passwordless import process_form_validation_errors as process_form_validation_errors
+
+BannerContainerMapping: TypeAlias = dict[str, BannerContainer]

--- a/src/cambiato/app/components/forms/__init__.py
+++ b/src/cambiato/app/components/forms/__init__.py
@@ -1,0 +1,1 @@
+r"""The form components."""

--- a/src/cambiato/app/components/forms/create_order_form.py
+++ b/src/cambiato/app/components/forms/create_order_form.py
@@ -1,0 +1,220 @@
+r"""The create order form component."""
+
+# Standard library
+from collections.abc import Sequence
+from enum import StrEnum
+
+# Third party
+import streamlit as st
+
+# Local
+from cambiato.app.components import keys
+from cambiato.app.components.core import BannerContainerMapping, process_form_validation_errors
+from cambiato.app.session_state import CREATE_ORDER_FORM_VALIDATION_ERRORS
+from cambiato.app.translations import CreateOrderForm, CreateOrderFormValidationMessage
+from cambiato.database import Session
+from cambiato.database.models import (
+    Checklist,
+    Facility,
+    Location,
+    Order,
+    OrderStatus,
+    OrderType,
+    User,
+)
+
+
+class FormField(StrEnum):
+    r"""The fields of the create order form to validate."""
+
+    SCHEDULED_START_TIME = 'scheduled_start_time'
+    SCHEDULED_END_TIME = 'scheduled_end_time'
+
+
+def _validate_form(translation: CreateOrderFormValidationMessage) -> None:
+    r"""Validate the input fields of the create order form.
+
+    Parameters
+    ----------
+    translation : cambiato.app.translation.CreateOrderFormValidationMessage
+        The translations for the validation errors.
+    """
+
+    validation_errors = {}
+
+    start_time = st.session_state[keys.CREATE_ORDER_FORM_SCHEDULED_START_TIME_INPUT]
+    end_time = st.session_state[keys.CREATE_ORDER_FORM_SCHEDULED_END_TIME_INPUT]
+
+    if start_time is None and end_time is None:
+        pass
+
+    elif start_time is None and end_time is not None:
+        validation_errors[FormField.SCHEDULED_START_TIME] = translation.start_time_no_end_time
+
+    elif start_time is not None and end_time is None:
+        validation_errors[FormField.SCHEDULED_END_TIME] = translation.end_time_no_start_time
+
+    elif start_time >= end_time:
+        validation_errors[FormField.SCHEDULED_START_TIME] = (
+            translation.start_time_geq_end_time.format(start_time=start_time, end_time=end_time)
+        )
+
+    else:
+        pass
+
+    st.session_state[CREATE_ORDER_FORM_VALIDATION_ERRORS] = validation_errors
+
+
+def create_order_form(
+    session: Session,
+    order_types: Sequence[OrderType],
+    order_statuses: Sequence[OrderStatus],
+    facilities: Sequence[Facility],
+    locations: Sequence[Location],
+    checklists: Sequence[Checklist],
+    technicians: Sequence[User],
+    translation: CreateOrderForm,
+    border: bool = True,
+    title: bool = True,
+    key: str = keys.CREATE_ORDER_FORM,
+) -> Order | None:
+    r"""Render the form for creating an order.
+
+    Parameters
+    ----------
+    session : cambiato.db.Session
+        An active database session.
+
+    order_types : Sequence[cambiato.db.models.OrderType]
+        The selectable order types of the order to create.
+
+    order_statuses : Sequence[cambiato.db.models.OrderStatus]
+        The selectable order statuses of the order to create.
+
+    facilities : Sequence[cambiato.db.models.Facility]
+        The selectable facilities that can be assigned to the order.
+
+    locations : Sequence[cambiato.db.models.Location]
+        The selectable locations that can be assigned to the order.
+
+    checklists : Sequence[cambiato.db.models.Checklist]
+        The selectable checklists that can be assigned to the order.
+
+    technicians : Sequence[cambiato.db.models.User]
+        The selectable technicians that can be assigned to the order.
+
+    translation : cambiato.app.translations.CreateOrderForm
+        The language translations for the form.
+
+    border : bool, default True
+        True if a border should be rendered around the form and False for no border.
+
+    title : bool, default True
+        True if the title of the form should be rendered.
+        Useful for removing the title if rendering the form in a dialog frame.
+
+    key : str, default cambiato.app.components.keys.CREATE_ORDER_FORM
+        The unique identifier of the form in the session state.
+    """
+
+    banner_container_mapping: BannerContainerMapping = {}
+
+    with st.form(key=key, border=border):
+        if title:
+            st.markdown(f'### {translation.title}')
+
+        order_type_id = st.selectbox(
+            label=translation.order_type_id_label,
+            placeholder=translation.order_type_id_placeholder,
+            options=order_types,
+            disabled=not bool(order_types),
+            key=keys.CREATE_ORDER_FORM_ORDER_TYPE_SELECTBOX,
+        )
+        order_status_id = st.selectbox(
+            label=translation.order_status_id_label,
+            placeholder=translation.order_status_id_placeholder,
+            options=order_statuses,
+            disabled=not bool(order_statuses),
+            key=keys.CREATE_ORDER_FORM_ORDER_STATUS_SELECTBOX,
+        )
+        facility_id = st.selectbox(
+            label=translation.facility_id_label,
+            placeholder=translation.facility_id_placeholder,
+            options=facilities,
+            index=None,
+            disabled=not bool(facilities),
+            key=keys.CREATE_ORDER_FORM_FACILITY_SELECTBOX,
+        )
+        location_id = st.selectbox(
+            label=translation.location_id_label,
+            placeholder=translation.location_id_placeholder,
+            options=locations,
+            index=None,
+            disabled=not bool(locations),
+            key=keys.CREATE_ORDER_FORM_LOCATION_SELECTBOX,
+        )
+        checklist_id = st.selectbox(
+            label=translation.checklist_id_label,
+            placeholder=translation.checklist_id_placeholder,
+            options=checklists,
+            index=None,
+            disabled=not bool(checklists),
+            key=keys.CREATE_ORDER_FORM_CHECKLIST_SELECTBOX,
+        )
+        ext_id = st.text_input(
+            label=translation.ext_id_label,
+            placeholder=translation.ext_id_placeholder,
+            key=keys.CREATE_ORDER_FORM_EXT_ID_TEXT_INPUT,
+        )
+        technician_id = st.selectbox(
+            label=translation.technician_id_label,
+            placeholder=translation.technician_id_placeholder,
+            options=technicians,
+            index=None,
+            disabled=not bool(technicians),
+            key=keys.CREATE_ORDER_FORM_TECHNICIAN_SELECTBOX,
+        )
+
+        left_col, mid_col, right_col = st.columns(3)
+        with left_col:
+            scheduled_start_at = st.date_input(
+                label=translation.scheduled_date,
+                value=None,
+                format='YYYY-MM-DD',
+                key=keys.CREATE_ORDER_FORM_SCHEDULED_DAY_DATE_INPUT,
+            )
+        with mid_col:
+            banner_container_mapping[FormField.SCHEDULED_START_TIME] = st.empty()
+            scheduled_start_at_time = st.time_input(
+                label=translation.scheduled_start_at,
+                value=None,
+                key=keys.CREATE_ORDER_FORM_SCHEDULED_START_TIME_INPUT,
+            )
+        with right_col:
+            banner_container_mapping[FormField.SCHEDULED_END_TIME] = st.empty()
+            scheduled_end_time = st.time_input(
+                label=translation.scheduled_end_at,
+                value=None,
+                key=keys.CREATE_ORDER_FORM_SCHEDULED_END_TIME_INPUT,
+            )
+
+        clicked = st.form_submit_button(
+            label=translation.submit_button_label,
+            type='primary',
+            on_click=_validate_form,
+            kwargs={'translation': translation.validation_messages},
+        )
+
+        if not clicked:
+            return None
+
+        if validation_errors := st.session_state.get(CREATE_ORDER_FORM_VALIDATION_ERRORS, {}):
+            process_form_validation_errors(
+                validation_errors=validation_errors,
+                banner_container_mapping=banner_container_mapping,
+            )
+            st.session_state[CREATE_ORDER_FORM_VALIDATION_ERRORS] = {}
+
+            return None
+
+        return None

--- a/src/cambiato/app/components/keys.py
+++ b/src/cambiato/app/components/keys.py
@@ -1,0 +1,13 @@
+r"""The keys of the components of the app."""
+
+CREATE_ORDER_FORM = 'create-order-form'
+CREATE_ORDER_FORM_ORDER_TYPE_SELECTBOX = 'create-order-form-order-type-selectbox'
+CREATE_ORDER_FORM_ORDER_STATUS_SELECTBOX = 'create-order-form-order-status-selectbox'
+CREATE_ORDER_FORM_FACILITY_SELECTBOX = 'create-order-form-facility-selectbox'
+CREATE_ORDER_FORM_LOCATION_SELECTBOX = 'create-order-form-location-selectbox'
+CREATE_ORDER_FORM_CHECKLIST_SELECTBOX = 'create-order-form-checklist-selectbox'
+CREATE_ORDER_FORM_EXT_ID_TEXT_INPUT = 'create-order-form-ext-id-text-input'
+CREATE_ORDER_FORM_TECHNICIAN_SELECTBOX = 'create-order-form-technician-selectbox'
+CREATE_ORDER_FORM_SCHEDULED_DAY_DATE_INPUT = 'create-order-form-scheduled-day-date-input'
+CREATE_ORDER_FORM_SCHEDULED_START_TIME_INPUT = 'create-order-form-scheduled-start-time-input'
+CREATE_ORDER_FORM_SCHEDULED_END_TIME_INPUT = 'create-order-form-scheduled-end-time-input'

--- a/src/cambiato/app/controller/order.py
+++ b/src/cambiato/app/controller/order.py
@@ -1,0 +1,35 @@
+r"""The page controller of the order page."""
+
+# Third party
+import streamlit as st
+
+# Local
+from cambiato.app.components.forms.create_order_form import create_order_form
+from cambiato.app.translations import Order
+from cambiato.database import Session
+
+
+def controller(session: Session, translation: Order) -> None:
+    r"""Render the order page.
+
+    Parameters
+    ----------
+    session : cambiato.db.Session
+        An active database session.
+
+    translation : cambiato.app.translations.Order
+        The translations for the order page.
+    """
+
+    st.title(translation.page_title)
+
+    create_order_form(
+        session=session,
+        order_types=[],
+        order_statuses=[],
+        facilities=[],
+        locations=[],
+        checklists=[],
+        technicians=[],
+        translation=translation.create_order_form,
+    )

--- a/src/cambiato/app/main.py
+++ b/src/cambiato/app/main.py
@@ -24,6 +24,7 @@ def main() -> None:
     pages = [
         st.Page(page=Pages.HOME, title='Home'),
         st.Page(page=Pages.SIGN_IN, title='Sign in and register', default=True),
+        st.Page(page=Pages.ORDER, title='Order'),
     ]
     page = st.navigation(pages, position='top' if authenticated else 'hidden')
 

--- a/src/cambiato/app/session_state.py
+++ b/src/cambiato/app/session_state.py
@@ -2,3 +2,6 @@ r"""Keys of the session state of the web app."""
 
 # True if the user is authenticated and False otherwise.
 AUTHENTICATED = 'authenticated'
+
+# The validation errors for the create order form.
+CREATE_ORDER_FORM_VALIDATION_ERRORS = 'create-order-form-validation-errors'

--- a/src/cambiato/app/setup.py
+++ b/src/cambiato/app/setup.py
@@ -10,6 +10,7 @@ import streamlit_passwordless as stp
 # Local
 from cambiato import exceptions
 from cambiato.app.config import ICON_ERROR
+from cambiato.app.translations import load_translation
 from cambiato.config import load_config
 from cambiato.database import create_session_factory
 from cambiato.log import setup_logging
@@ -43,3 +44,5 @@ except exceptions.SQLAlchemyError as e:
 bwp_client = stp.BitwardenPasswordlessClient(
     public_key=cm.bwp.public_key, private_key=cm.bwp.private_key
 )
+
+translations = {lang: load_translation(lang) for lang in cm.languages}

--- a/src/cambiato/app/translations/__init__.py
+++ b/src/cambiato/app/translations/__init__.py
@@ -1,0 +1,16 @@
+r"""Language translations for the application."""
+
+# Local
+from cambiato.app.translations.core import TranslationModel, load_translation
+from cambiato.app.translations.order import CreateOrderForm, CreateOrderFormValidationMessage, Order
+
+# The Public API
+__all__ = [
+    # core
+    'TranslationModel',
+    'load_translation',
+    # order
+    'CreateOrderForm',
+    'CreateOrderFormValidationMessage',
+    'Order',
+]

--- a/src/cambiato/app/translations/core.py
+++ b/src/cambiato/app/translations/core.py
@@ -1,0 +1,40 @@
+r"""Core functionality to work with translations."""
+
+# Standard library
+from importlib.resources import files
+
+# Local
+from cambiato.app.translations.order import Order
+from cambiato.config import Language
+from cambiato.models.core import BaseModel
+
+
+class TranslationModel(BaseModel):
+    r"""The model of the translations.
+
+    Parameters
+    ----------
+    order : cambiato.translations.Order
+        The translations for the order page.
+    """
+
+    order: Order
+
+
+def load_translation(language: Language) -> TranslationModel:
+    r"""Load the translations for the selected language.
+
+    Parameters
+    ----------
+    language : cambiato.config.Language
+        The translation language to load.
+
+    Returns
+    -------
+    cambiato.app.translations.TranslationModel
+        The model of the translations for the application.
+    """
+
+    lang_file = files('cambiato.app.translations.translations').joinpath(f'{language}.json')
+
+    return TranslationModel.model_validate_json(lang_file.read_text())

--- a/src/cambiato/app/translations/order.py
+++ b/src/cambiato/app/translations/order.py
@@ -1,0 +1,45 @@
+r"""The translation models for the order page."""
+
+# Local
+from cambiato.models.core import BaseModel
+
+
+class CreateOrderFormValidationMessage(BaseModel):
+    r"""Validation messages for the create order form."""
+
+    start_time_no_end_time: str
+    end_time_no_start_time: str
+    start_time_geq_end_time: str
+
+
+class CreateOrderForm(BaseModel):
+    r"""The translation of the create order form."""
+
+    title: str
+    department_id: str
+    order_type_id_label: str
+    order_type_id_placeholder: str
+    order_status_id_label: str
+    order_status_id_placeholder: str
+    ext_id_label: str
+    ext_id_placeholder: str
+    facility_id_label: str
+    facility_id_placeholder: str
+    location_id_label: str
+    location_id_placeholder: str
+    checklist_id_label: str
+    checklist_id_placeholder: str
+    technician_id_label: str
+    technician_id_placeholder: str
+    scheduled_date: str
+    scheduled_start_at: str
+    scheduled_end_at: str
+    submit_button_label: str
+    validation_messages: CreateOrderFormValidationMessage
+
+
+class Order(BaseModel):
+    r"""The translation of the order page."""
+
+    page_title: str
+    create_order_form: CreateOrderForm

--- a/src/cambiato/app/translations/translations/en.json
+++ b/src/cambiato/app/translations/translations/en.json
@@ -1,0 +1,32 @@
+{
+    "order": {
+        "page_title": "Order",
+        "create_order_form" : {
+            "title": "Create Order",
+            "department_id": "Department",
+            "order_type_id_label": "Order Type",
+            "order_type_id_placeholder": "Order Type",
+            "order_status_id_label": "Order Status",
+            "order_status_id_placeholder": "Order Status",
+            "ext_id_label": "External ID",
+            "ext_id_placeholder": "External ID",
+            "facility_id_label": "Facility ID",
+            "facility_id_placeholder": "Facility ID",
+            "location_id_label": "Location ID",
+            "location_id_placeholder": "Location ID",
+            "checklist_id_label": "Checklist",
+            "checklist_id_placeholder": "Checklist",
+            "technician_id_label": "Technician",
+            "technician_id_placeholder": "Assign to Technician",
+            "scheduled_date": "Scheduled Day",
+            "scheduled_start_at": "Scheduled Start Time",
+            "scheduled_end_at": "Scheduled End Time",
+            "submit_button_label": "Create",
+            "validation_messages": {
+                "start_time_no_end_time": "Start time must be specified if end time is!",
+                "end_time_no_start_time": "End time must be specified if start time is!",
+                "start_time_geq_end_time": "start time ({start_time}) must be < end time ({end_time})!"
+            }
+        }
+    }
+}

--- a/src/cambiato/config/config.py
+++ b/src/cambiato/config/config.py
@@ -32,8 +32,11 @@ class ConfigManager(BaseConfigModel):
         The special path '-' specifies that the config was loaded from stdin.
         If None the default configuration was loaded.
 
-    language : cambiato.Language, default cambiato.Language.EN
-        The default language to use when starting the application. The default is English.
+    languages : tuple[cambiato.Language, ...], default (cambiato.Language.EN,)
+        The languages to make available to the application. The default is English.
+
+    default_language : cambiato.Language, default cambiato.Language.EN
+        The default language to use when the application first loads. The default is English.
 
     database : cambiato.DatabaseConfig
         The database configuration.
@@ -48,7 +51,8 @@ class ConfigManager(BaseConfigModel):
     model_config = ConfigDict(frozen=True)
 
     config_file_path: Path | None = None
-    language: Language = Language.EN
+    languages: tuple[Language, ...] = (Language.EN,)
+    default_language: Language = Language.EN
     database: DatabaseConfig = Field(default_factory=DatabaseConfig)
     bwp: BitwardenPasswordlessConfig = Field(
         validation_alias=AliasChoices('bwp', 'bitwarden_passwordless', 'bitwarden_passwordless_dev')

--- a/src/cambiato/config/core.py
+++ b/src/cambiato/config/core.py
@@ -32,10 +32,13 @@ BITWARDEN_PASSWORDLESS_API_URL = stp.BITWARDEN_PASSWORDLESS_API_URL
 
 
 class Language(StrEnum):
-    r"""The available languages of Cambiato."""
+    r"""The available languages of Cambiato.
 
-    EN = 'English'
-    SV = 'Swedish'
+    Uses ISO 639 two letter abbreviations.
+    """
+
+    EN = 'en'
+    SV = 'sv'
 
 
 class BaseConfigModel(BaseModel):

--- a/src/cambiato/database/models/__init__.py
+++ b/src/cambiato/database/models/__init__.py
@@ -1,5 +1,8 @@
 r"""The database tables."""
 
+# Third party
+from streamlit_passwordless.database.models import CustomRole, Email, Role, User, UserSignIn
+
 # Local
 from .core import (
     SCHEMA,
@@ -103,4 +106,10 @@ __all__ = [
     'OrderStatus',
     'OrderType',
     'PhoneType',
+    # streamlit-passwordless
+    'CustomRole',
+    'Email',
+    'Role',
+    'User',
+    'UserSignIn',
 ]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -111,7 +111,8 @@ def config_data(tmp_path: Path) -> tuple[str, dict[str, Any]]:
     }
 
     config_exp = {
-        'language': Language.EN,
+        'languages': (Language.EN,),
+        'default_language': Language.EN,
         'database': database_config,
         'bwp': bwp_config,
         'logging': logging_config,


### PR DESCRIPTION
The page will facilitate creation and management of orders. At this stage the page includes the non-finished `create_order_form`.

Adding a first draft of how language translations can work within the app. 